### PR TITLE
Fix for Validation.prototype.ap

### DIFF
--- a/validation.js
+++ b/validation.js
@@ -30,12 +30,13 @@ Validation.prototype.map = function(f) {
     return this.bimap(identity, f);
 };
 Validation.prototype.ap = function(b) {
-    return this.fold(
+    var self = this;
+    return b.fold(
         function(f) {
             return Validation.Failure(f);
         },
         function(s) {
-            return b.map(s);
+            return self.map(s);
         }
     );
 };

--- a/validation.js
+++ b/validation.js
@@ -32,8 +32,16 @@ Validation.prototype.map = function(f) {
 Validation.prototype.ap = function(b) {
     var self = this;
     return b.fold(
-        function(f) {
-            return Validation.Failure(f);
+        function(f1) {
+            return self.fold(
+                function (f2) {
+                    return Validation.Failure(f1.concat(f2));
+                },
+                function (s) {
+                    return Validation.Failure(f1);
+                }
+            );
+            return Validation.Failure(f1);
         },
         function(s) {
             return self.map(s);


### PR DESCRIPTION
I wrote a little test script:

``` javascript
var Validation = require('./validation.js'),
    sorcery = require('../fantasy-sorcery/index.js');

var positive = function (x) {
    return x > 0 ? Validation.of(x) : Validation.Failure(x + ' not positive');
};

var lessThan = function (x, y) {
    return x < y ? Validation.of(x) : Validation.Failure(x + ' not less than ' + y);
};

var f = function (x) {
    return sorcery.lift2(
        function (a, b) { return x; },
        positive(x),
        lessThan(x, 10)
    );
};

console.log('positive:', positive(-5).f);
console.log('lessThan:', lessThan(20, 10).f);
console.log('f(-5):', f(-5).f);
console.log('f(5):', f(5).s);
console.log('f(20):', f(20).f);
```

The output is

```
positive: -5 not positive
lessThan: 20 not less than 10
f(-5): -5 not positive

/home/ben/code/fantasy-validations/validation.js:25
            return Validation.Success(g(b));
                                      ^
TypeError: number is not a function
    at definitions.<anonymous> (/home/ben/code/fantasy-validations/validation.js:25:39)
    at definitions.cata (/home/ben/code/fantasy-validations/node_modules/daggy/daggy.js:134:40)
    at definitions.Validation.fold (/home/ben/code/fantasy-validations/validation.js:13:17)
    at definitions.Validation.bimap (/home/ben/code/fantasy-validations/validation.js:20:17)
    at definitions.Validation.map (/home/ben/code/fantasy-validations/validation.js:30:17)
    at definitions.<anonymous> (/home/ben/code/fantasy-validations/validation.js:39:22)
    at definitions.cata (/home/ben/code/fantasy-validations/node_modules/daggy/daggy.js:134:40)
    at definitions.Validation.fold (/home/ben/code/fantasy-validations/validation.js:13:17)
    at definitions.Validation.ap (/home/ben/code/fantasy-validations/validation.js:34:17)
    at ap (/home/ben/code/fantasy-sorcery/index.js:56:23)
```

Which this patch fixes.  Please let me know if I've gotten something wrong.  Cheers,

Ben
